### PR TITLE
ci: Fetch tags in publish release workflow

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -71,6 +71,9 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v5
         with:
+          # This is to guarantee that the most recent tag is fetched, which we
+          # need for updating the shorthand major version tag.
+          fetch-depth: 0
           ref: ${{ github.sha }}
       - name: Publish release
         uses: MetaMask/action-publish-release@v3


### PR DESCRIPTION
This fixes updating the tags in the `update-major-version-tag.sh` script. Previously the `v1` tag wasn't fetched on checkout, so it couldn't be deleted (to be recreated afterwards).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Ensure tags are fetched in the publish-release workflow by setting checkout `fetch-depth: 0` to allow updating the shorthand major version tag.
> 
> - **CI/CD**:
>   - Update `/.github/workflows/publish-release.yml` to set `actions/checkout` `fetch-depth: 0`, ensuring tags are fetched so `update-major-version-tag.sh` can update the shorthand major version tag.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 985c670c115f7cd6b739ed0d89d8fd446f5710a8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->